### PR TITLE
Add JS version argument `--language_in ECMASCRIPT5`

### DIFF
--- a/assetman/compilers.py
+++ b/assetman/compilers.py
@@ -138,6 +138,7 @@ class JSCompiler(AssetCompiler, assetman.managers.JSManager):
         cmd = [
             self.required_setting_file("java_bin"), '-Xss16m', '-jar', self.required_setting_file("closure_compiler"),
             '--compilation_level', 'SIMPLE_OPTIMIZATIONS',
+            '--language_in', 'ECMASCRIPT5',
             ]
         for path in self.get_paths():
             cmd.extend(('--js', path))


### PR DESCRIPTION
New version of Closure Compiler differentiates JavaScript versions. 

Without specification of `language_in`, it defaults to `ECMASCRIPT3`, which is too old for us. 