### PR TITLE
bugfix base64 file decoding

### DIFF
--- a/assetman/compilers.py
+++ b/assetman/compilers.py
@@ -200,7 +200,7 @@ class CSSCompiler(AssetCompiler, assetman.managers.CSSManager):
                 logging.debug('Not inlining %s (%.2fKB)', path, os.stat(path).st_size / KB)
                 return match.group(0)
             else:
-                encoded = base64.b64encode(open(path).read())
+                encoded = base64.b64encode(open(path, 'rb').read())
                 mime_type, _ = mimetypes.guess_type(path)
                 if not mime_type and path.endswith('.otf'):
                     mime_type = 'application/octet-stream'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pyassetman"
 description = "assetman assetmanager"
-version = "0.3.0rc1"
+version = "0.3.0rc2"
 authors = [
   { name="Will McCutchen", email="wm@bit.ly" },
 ]
 maintainers = [
   { name="Jehiah Czebotar", email="jehiah@gmail.com"},
-  { name="Josh Harshman", email="josh.harshman@bit.ly"}
+  { name="Josh Harshman", email="josh.harshman@bit.ly"},
+  { name="Oscar Luu", email="oscar.luu@bit.ly"}
 ]
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
This PR fixes a bug where the file opener tries to decode files into utf-8 when some files are not necessarily text files. 

Opens it in binary mode and base64 encodes this. 

Error:
```
"/home/local/python39_venv/lib/python3.9/site-packages/assetman/compilers.py", line 203, in replacer
    encoded = base64.b64encode(open(path).read())
  File "/home/local/lib/python3.9/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
```