### PR TITLE
S3UploadThread fix bug with regex search on bytes

### DIFF
--- a/assetman/S3UploadThread.py
+++ b/assetman/S3UploadThread.py
@@ -10,7 +10,7 @@ import queue as Queue
 import mimetypes
 import logging
 import boto3
-from assetman.tools import make_output_path, make_absolute_static_path, make_relative_static_path, get_static_pattern, get_shard_from_list
+from assetman.tools import make_output_path, make_absolute_static_path, make_relative_static_path, get_static_pattern, get_shard_from_list, _unicode
 
 class S3UploadThread(threading.Thread):
     """Thread that knows how to read asset file names from a queue and upload
@@ -89,7 +89,7 @@ class S3UploadThread(threading.Thread):
         try:
             self.client.head_object(Bucket=obj.bucket_name, Key=obj.key)
         except Exception as e:
-            logging.error('got %s', e)
+            logging.error('got %s when searching for %s', e, obj.key)
             return False
         return True
 
@@ -137,7 +137,6 @@ def upload_assets_to_s3(manifest, settings, skip_s3_upload=False):
     """Uploads any assets that are in the given manifest and in our compiled
     output dir but missing from our static assets bucket to that bucket on S3.
     """
-
     # We will gather a set of (file_name, file_path) tuples to be uploaded
     to_upload = set()
 
@@ -205,4 +204,4 @@ def sub_static_version(src, manifest, replacement_prefix, static_dir, static_url
         logging.warning('Missing path %s in manifest, using %s', path, match.group(0))
         return match.group(0)
     pattern = get_static_pattern(static_url_prefix)
-    return re.sub(pattern, replacer, src)
+    return re.sub(pattern, replacer, _unicode(src))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pyassetman"
 description = "assetman assetmanager"
-version = "0.3.0rc3"
+version = "0.3.0rc4"
 authors = [
   { name="Will McCutchen", email="wm@bit.ly" },
 ]


### PR DESCRIPTION
Fixes a bug where S3UploadThread tries to do regex on a bytes object.

```
[E 240708 22:31:58 S3UploadThread:46] Error uploading barfoo: cannot use a string pattern on a bytes-like object
[E 240708 22:31:59 S3UploadThread:46] Error uploading foobar: cannot use a string pattern on a bytes-like object
Exception: [((<class 'TypeError'>, TypeError('cannot use a string pattern on a bytes-like object'), <traceback object at 0x7f9ec8846d80>), <S3UploadThread(Thread-9, started daemon 140319659054848)>), ((<class 'TypeError'>, TypeError('cannot use a string pattern on a bytes-like object'), <traceback object at 0x7f9eb41d60c0>), <S3UploadThread(Thread-9, started daemon 140319659054848)>)]
```
