### PR TITLE
Bugfix: compiler asset type fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,9 @@ jobs:
         python -m pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         sudo apt-get update
-        sudo apt-get install minify
+        sudo apt-get install -y wget minify
+        wget "https://dl.google.com/closure-compiler/compiler-20150315.zip"
+        unzip compiler-20150315.zip compiler.jar
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        sudo apt-get update
+        sudo apt-get install minify
     - name: Test with pytest
       run: |
         pytest

--- a/assetman/compilers.py
+++ b/assetman/compilers.py
@@ -11,7 +11,7 @@ import os
 import re
 
 import assetman.managers
-from assetman.tools import make_absolute_static_path, make_relative_static_path, get_static_pattern, make_output_path
+from assetman.tools import make_absolute_static_path, make_relative_static_path, get_static_pattern, make_output_path, _unicode
 
 def run_proc(cmd, stdin=None):
     """Runs the given cmd as a subprocess. If the exit code is non-zero, calls
@@ -200,7 +200,8 @@ class CSSCompiler(AssetCompiler, assetman.managers.CSSManager):
                 logging.debug('Not inlining %s (%.2fKB)', path, os.stat(path).st_size / KB)
                 return match.group(0)
             else:
-                encoded = base64.b64encode(open(path, 'rb').read())
+                # data_uri format requires strings instead of bytes
+                encoded = _unicode(base64.b64encode(open(path, 'rb').read()))
                 mime_type, _ = mimetypes.guess_type(path)
                 if not mime_type and path.endswith('.otf'):
                     mime_type = 'application/octet-stream'

--- a/assetman/tests/test_compiler.py
+++ b/assetman/tests/test_compiler.py
@@ -43,8 +43,8 @@ def run_compiler(test_needs_compile=True, **opts):
     always cause skip_upload to be True, so that we don't upload test assets
     to our CDN.
     """
-
-    manifest = assetman.compile.run(get_settings(test_needs_compile=test_needs_compile, **opts))
+    minify_compressor_path = "/usr/bin/minify"
+    manifest = assetman.compile.run(get_settings(test_needs_compile=test_needs_compile, minify_compressor_path=minify_compressor_path, **opts))
     logging.debug(manifest)
     return manifest
 

--- a/assetman/tests/test_compiler.py
+++ b/assetman/tests/test_compiler.py
@@ -44,7 +44,8 @@ def run_compiler(test_needs_compile=True, **opts):
     to our CDN.
     """
     minify_compressor_path = "/usr/bin/minify"
-    manifest = assetman.compile.run(get_settings(test_needs_compile=test_needs_compile, minify_compressor_path=minify_compressor_path, **opts))
+    closure_compiler = "compiler.jar"
+    manifest = assetman.compile.run(get_settings(test_needs_compile=test_needs_compile, minify_compressor_path=minify_compressor_path, closure_compiler=closure_compiler, **opts))
     logging.debug(manifest)
     return manifest
 

--- a/assetman/tests/test_compiler.py
+++ b/assetman/tests/test_compiler.py
@@ -24,8 +24,8 @@ def get_settings(**opts):
                     skip_s3_upload=True,
                     force_recompile=False,
                     skip_inline_images=True,
-                    closure_compiler=opts.get("closure_compiler", "/bitly/local/bin/closure-compiler.jar"),
-                    minify_compressor_path=opts.get("minify_compressor_path", "/bitly/local/bin/minify"),
+                    closure_compiler=opts.get("closure_compiler", "compiler.jar"),
+                    minify_compressor_path=opts.get("minify_compressor_path", "/usr/bin/minify"),
                     sass_compiler=opts.get("sass_compiler", None),
                     lessc_path=opts.get("lessc_path", None), # less is unused
                     aws_username=None,
@@ -43,9 +43,7 @@ def run_compiler(test_needs_compile=True, **opts):
     always cause skip_upload to be True, so that we don't upload test assets
     to our CDN.
     """
-    minify_compressor_path = "/usr/bin/minify"
-    closure_compiler = "compiler.jar"
-    manifest = assetman.compile.run(get_settings(test_needs_compile=test_needs_compile, minify_compressor_path=minify_compressor_path, closure_compiler=closure_compiler, **opts))
+    manifest = assetman.compile.run(get_settings(test_needs_compile=test_needs_compile, **opts))
     logging.debug(manifest)
     return manifest
 

--- a/assetman/tests/test_compiler.py
+++ b/assetman/tests/test_compiler.py
@@ -26,8 +26,8 @@ def get_settings(**opts):
                     skip_inline_images=True,
                     closure_compiler=opts.get("closure_compiler", "/bitly/local/bin/closure-compiler.jar"),
                     minify_compressor_path=opts.get("minify_compressor_path", "/bitly/local/bin/minify"),
-                    sass_compiler=opts.get("sass_compiler", "/bitly/local/bin/sass"),
-                    lessc_path=opts.get("lessc_path", "/bitly/local/hamburger/node_modules/.bin/lessc"), # lessc is included as a node module in hamburger. Does not exist in /bitly/local/bin/
+                    sass_compiler=opts.get("sass_compiler", None),
+                    lessc_path=opts.get("lessc_path", None), # less is unused
                     aws_username=None,
                     java_bin="/usr/bin/java",
                     )
@@ -49,7 +49,7 @@ def run_compiler(test_needs_compile=True, **opts):
     return manifest
 
 def test_needs_compile():
-    main_files = ["test.css", "test.less", "test.js"]
+    main_files = ["test.css", "test.js"]
     dependency_files = ["dependency.png"]
     try:
         manifest = run_compiler()
@@ -79,7 +79,7 @@ def test_needs_compile():
     
     files_to_upload = upload_assets_to_s3(manifest, get_settings(), skip_s3_upload=True)
     logging.debug(files_to_upload)
-    assert len(files_to_upload) == 4
+    assert len(files_to_upload) == 3
     
 
 @contextlib.contextmanager
@@ -88,6 +88,7 @@ def temporarily_alter_contents(path, data):
     before restoring the original contents when the with block is exited.
     """
     assert isinstance(data, str)
+    path = 'assetman/tests/%s' % path
     contents = open(path).read()
     open(path, 'a').write(data)
     yield

--- a/assetman/tests/test_settings.py
+++ b/assetman/tests/test_settings.py
@@ -10,8 +10,8 @@ class TestSettings(unittest.TestCase):
         settings_stub = {
             'testkey1': "testvalue1",
             'testkey2': "testvalue2",
-            "lessc_path" : "asdf",
             "sass_compiler": "asdf",
+            "lessc_path": None,
             "minify_compressor_path": "asdf",
             "closure_compiler": "asdf",
             "java_bin": "asdf"

--- a/assetman/tests/test_tornado_templates.py
+++ b/assetman/tests/test_tornado_templates.py
@@ -1,6 +1,6 @@
 import unittest
 
-from assetman.compilers import JSCompiler, LessCompiler, CSSCompiler
+from assetman.compilers import JSCompiler, CSSCompiler
 from assetman.parsers.tornado_parser import TornadoParser
 import assetman.tools
 from assetman.settings import Settings
@@ -30,7 +30,6 @@ class TestTornadoTemplateParser(unittest.TestCase):
         compiler_types = [type(t) for t in compilers]
 
         assert JSCompiler in compiler_types, compilers
-        assert LessCompiler in compiler_types, compilers
         assert CSSCompiler in compiler_types, compilers
 
 if __name__ == "__main__":

--- a/assetman/tests/tornado_templates/tornado_test_template.html
+++ b/assetman/tests/tornado_templates/tornado_test_template.html
@@ -3,9 +3,6 @@
         {% apply assetman.include_css %}
             test.css
         {% end %}
-        {% apply assetman.include_less %}
-            test.less
-        {% end %}
     </head>
     <body>
         <div>

--- a/assetman/tornadoutils/static.py
+++ b/assetman/tornadoutils/static.py
@@ -169,7 +169,8 @@ class LessCompilerHandler(CompilingStaticHandler):
         env = {
             'PATH': os.environ.get('PATH', '') 
         }
-        return self.run_proc(cmd, env=env)
+        out = self.run_proc(cmd, env=env)
+        return out
 
 
 class SassCompilerHandler(CompilingStaticHandler):


### PR DESCRIPTION
Due to the python2 -> python3 migrations, data uri's need to have the proper typing to be able to reference assets correctly. 

Base64 encoding returns bytestrings which then are referenced in data_uri's that look like this:
```
url(data:image/svg+xml;base64,b'SIgeG1sbnM9Imh0')
```

```python
>>> encoded = base64.b64encode(open('sample.svg', 'rb').read())
>>> encoded
b'D0iNDAiIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgMCA0MCA0MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLz'
```

In order to fix this, we should decode the byte string into string to allow the proper decoding of the data_uri.
```python
>>> encoded = base64.b64encode(open('sample.svg', 'rb').read()).decode('utf-8')
>>> encoded
'D0iNDAiIGhlaWdodD0iNDAiIHZpZXdCb3g9IjAgMCA0MCA0MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLz'
```

This PR also addresses testing and ensuring github actions testing works properly and as intended