### PR TITLE
upgrade boto & urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 aadict==0.2.3
 asgiref==3.7.2
 asset==0.6.13
-boto3==1.34.15
-botocore==1.34.15
+boto3==1.38.45
+botocore==1.38.45
 exceptiongroup==1.2.0
 globre==0.1.5
 iniconfig==2.0.0
@@ -11,8 +11,8 @@ packaging==23.2
 pluggy==1.3.0
 pytest==7.4.4
 python-dateutil==2.8.2
-s3transfer==0.10.0
+s3transfer==0.13.0
 six==1.16.0
 tornado==6.5.1
-typing-extensions==4.9.0
-urllib3==1.26.19
+typing_extensions==4.9.0
+urllib3==2.5.0


### PR DESCRIPTION
boto has a version restriction on `urllib3` so this upgrades both

Closes #31